### PR TITLE
Rewrite and overhaul bulk compression system

### DIFF
--- a/common/src/data/java/gripe/_90/megacells/datagen/CommonTagProvider.java
+++ b/common/src/data/java/gripe/_90/megacells/datagen/CommonTagProvider.java
@@ -8,7 +8,8 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.tags.IntrinsicHolderTagsProvider;
 import net.minecraft.data.tags.ItemTagsProvider;
-import net.minecraft.tags.BlockTags;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
 
 import appeng.api.features.P2PTunnelAttunement;
@@ -18,8 +19,8 @@ import gripe._90.megacells.definition.MEGAItems;
 import gripe._90.megacells.definition.MEGATags;
 
 public class CommonTagProvider {
-    public static class Items extends ItemTagsProvider {
-        public Items(
+    public static class ItemTags extends ItemTagsProvider {
+        public ItemTags(
                 PackOutput output,
                 CompletableFuture<HolderLookup.Provider> registries,
                 CompletableFuture<TagLookup<Block>> blockTags) {
@@ -36,11 +37,20 @@ public class CommonTagProvider {
             tag(MEGATags.MEGA_PATTERN_PROVIDER)
                     .add(MEGABlocks.MEGA_PATTERN_PROVIDER.asItem())
                     .add(MEGAItems.MEGA_PATTERN_PROVIDER.asItem());
+
+            tag(MEGATags.COMPRESSION_OVERRIDES)
+                    .add(Items.QUARTZ)
+                    .add(Items.AMETHYST_SHARD)
+                    .add(Items.GLOWSTONE_DUST)
+                    .add(Items.CLAY_BALL)
+                    .add(Items.MELON_SLICE)
+                    .add(Items.MAGMA_CREAM)
+                    .addOptionalTag(new ResourceLocation("functionalstorage", "ignore_crafting_check"));
         }
     }
 
-    public static class Blocks extends IntrinsicHolderTagsProvider<Block> {
-        public Blocks(PackOutput packOutput, CompletableFuture<HolderLookup.Provider> registries) {
+    public static class BlockTags extends IntrinsicHolderTagsProvider<Block> {
+        public BlockTags(PackOutput packOutput, CompletableFuture<HolderLookup.Provider> registries) {
             super(packOutput, Registries.BLOCK, registries, block -> BuiltInRegistries.BLOCK
                     .getResourceKey(block)
                     .orElseThrow());
@@ -49,7 +59,7 @@ public class CommonTagProvider {
         @Override
         protected void addTags(HolderLookup.Provider provider) {
             for (var block : MEGABlocks.getBlocks()) {
-                tag(BlockTags.MINEABLE_WITH_PICKAXE).add(block.block());
+                tag(net.minecraft.tags.BlockTags.MINEABLE_WITH_PICKAXE).add(block.block());
             }
 
             tag(MEGATags.SKY_STEEL_BLOCK).add(MEGABlocks.SKY_STEEL_BLOCK.block());

--- a/common/src/main/java/gripe/_90/megacells/definition/MEGATags.java
+++ b/common/src/main/java/gripe/_90/megacells/definition/MEGATags.java
@@ -27,4 +27,7 @@ public final class MEGATags {
 
     public static final TagKey<Item> MEGA_PATTERN_PROVIDER =
             TagKey.create(Registries.ITEM, MEGACells.makeId("mega_pattern_provider"));
+
+    public static final TagKey<Item> COMPRESSION_OVERRIDES =
+            TagKey.create(Registries.ITEM, MEGACells.makeId("compression_overrides"));
 }

--- a/common/src/main/java/gripe/_90/megacells/item/cell/BulkCellInventory.java
+++ b/common/src/main/java/gripe/_90/megacells/item/cell/BulkCellInventory.java
@@ -3,14 +3,10 @@ package gripe._90.megacells.item.cell;
 import static gripe._90.megacells.definition.MEGAItems.COMPRESSION_CARD;
 
 import java.math.BigInteger;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.function.Function;
 
-import it.unimi.dsi.fastutil.Pair;
-import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2LongLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -24,7 +20,6 @@ import appeng.api.stacks.KeyCounter;
 import appeng.api.storage.cells.CellState;
 import appeng.api.storage.cells.ISaveProvider;
 import appeng.api.storage.cells.StorageCell;
-import appeng.util.prioritylist.IPartitionList;
 
 import gripe._90.megacells.item.MEGABulkCell;
 import gripe._90.megacells.service.CompressionService;
@@ -38,10 +33,8 @@ public class BulkCellInventory implements StorageCell {
 
     private AEItemKey storedItem;
     private final AEItemKey filterItem;
-    private final IPartitionList partitionList;
 
-    private final Object2IntMap<AEItemKey> compressed;
-    private final Object2IntMap<AEItemKey> decompressed;
+    private final Object2LongMap<AEItemKey> compressionChain;
     private BigInteger unitCount;
     private AEItemKey highestCompressed;
     private final long unitFactor;
@@ -53,16 +46,9 @@ public class BulkCellInventory implements StorageCell {
         this.i = o;
         this.container = container;
 
-        var config = cell.getConfigInventory(i);
-        this.filterItem = (AEItemKey) config.getKey(0);
-
-        var builder = IPartitionList.builder();
-        builder.addAll(config.keySet());
-        this.partitionList = builder.build();
-
-        this.compressed = CompressionService.getVariants(filterItem, false);
-        this.decompressed = CompressionService.getVariants(filterItem, true);
-        this.unitFactor = decompressed.values().intStream().asLongStream().reduce(1, Math::multiplyExact);
+        this.filterItem = (AEItemKey) cell.getConfigInventory(i).getKey(0);
+        this.compressionChain = CompressionService.getChain(filterItem).orElseGet(Object2LongLinkedOpenHashMap::new);
+        this.unitFactor = compressionChain.containsKey(filterItem) ? compressionChain.getLong(filterItem) : 1;
 
         this.storedItem = getTag().contains(KEY) ? AEItemKey.fromTag(getTag().getCompound(KEY)) : null;
         this.unitCount = !getTag().getString(UNIT_COUNT).isEmpty()
@@ -125,23 +111,22 @@ public class BulkCellInventory implements StorageCell {
             return 0;
         }
 
-        if (!compressionEnabled && (!partitionList.isListed(what) || storedItem != null && !storedItem.equals(what))) {
+        if (!compressionEnabled && (!filterItem.equals(what) || storedItem != null && !storedItem.equals(what))) {
             return 0;
         }
 
-        if (compressionEnabled
-                && !partitionList.isListed(what)
-                && !compressed.containsKey(item)
-                && !decompressed.containsKey(item)) {
+        if (compressionEnabled && !filterItem.equals(what) && !compressionChain.containsKey(what)) {
             return 0;
         }
 
-        var units = BigInteger.valueOf(amount).multiply(compressedTransferFactor(item));
+        var factor = BigInteger.valueOf(compressionChain.containsKey(item) ? compressionChain.getLong(item) : 1);
+        var units = BigInteger.valueOf(amount).multiply(factor);
 
         if (mode == Actionable.MODULATE) {
             if (storedItem == null) {
                 storedItem = filterItem;
             }
+
             unitCount = unitCount.add(units);
             saveChanges();
         }
@@ -156,6 +141,7 @@ public class BulkCellInventory implements StorageCell {
         }
 
         var itemCount = unitCount.divide(BigInteger.valueOf(unitFactor));
+
         if (!compressionEnabled && (itemCount.signum() < 1 || !storedItem.equals(what))) {
             return 0;
         }
@@ -163,13 +149,12 @@ public class BulkCellInventory implements StorageCell {
         if (compressionEnabled
                 && !storedItem.equals(what)
                 && !filterItem.equals(what)
-                && !compressed.containsKey(item)
-                && !decompressed.containsKey(item)) {
+                && !compressionChain.containsKey(item)) {
             return 0;
         }
 
-        var extractionFactor = compressedTransferFactor(item);
-        var units = BigInteger.valueOf(amount).multiply(extractionFactor);
+        var factor = BigInteger.valueOf(compressionChain.containsKey(item) ? compressionChain.getLong(item) : 1);
+        var units = BigInteger.valueOf(amount).multiply(factor);
         var currentUnitCount = unitCount;
 
         if (currentUnitCount.compareTo(units) <= 0) {
@@ -178,39 +163,16 @@ public class BulkCellInventory implements StorageCell {
                 unitCount = BigInteger.ZERO;
                 saveChanges();
             }
-            return clampedLong(currentUnitCount.divide(extractionFactor), Long.MAX_VALUE);
+
+            return clampedLong(currentUnitCount.divide(factor), Long.MAX_VALUE);
         } else {
             if (mode == Actionable.MODULATE) {
                 unitCount = unitCount.subtract(units);
                 saveChanges();
             }
-            return clampedLong(units.divide(extractionFactor), Long.MAX_VALUE);
+
+            return clampedLong(units.divide(factor), Long.MAX_VALUE);
         }
-    }
-
-    private BigInteger compressedTransferFactor(AEItemKey what) {
-        if (compressed.getInt(what) > 0) {
-            return compressedTransferFactor(compressed, unitFactor, keys -> Pair.of(0, keys.indexOf(what) + 1));
-        } else if (decompressed.getInt(what) > 0) {
-            return compressedTransferFactor(decompressed, 1, keys -> Pair.of(keys.indexOf(what) + 1, keys.size()));
-        } else {
-            return BigInteger.valueOf(unitFactor);
-        }
-    }
-
-    private BigInteger compressedTransferFactor(
-            Object2IntMap<AEItemKey> variants, long baseFactor, Function<List<?>, Pair<Integer, Integer>> subLister) {
-        var variantKeys = new LinkedList<>(variants.keySet());
-        var toStored = new Object2IntLinkedOpenHashMap<>(variants);
-
-        var range = subLister.apply(variantKeys);
-        toStored.keySet().retainAll(variantKeys.subList(range.first(), range.second()));
-
-        for (var i : toStored.values()) {
-            baseFactor *= i;
-        }
-
-        return BigInteger.valueOf(baseFactor);
     }
 
     private void saveChanges() {
@@ -246,37 +208,29 @@ public class BulkCellInventory implements StorageCell {
         if (storedItem != null) {
             var stackLimit = (long) Math.pow(2, 42);
 
-            if (compressionEnabled && storedItem.equals(filterItem)) {
-                var allVariants = new Object2IntLinkedOpenHashMap<AEItemKey>();
-
-                if (!decompressed.isEmpty()) {
-                    var decompressedKeys = new LinkedList<>(decompressed.keySet());
-                    Collections.reverse(decompressedKeys);
-                    decompressedKeys.forEach(k -> allVariants.put(k, decompressed.getInt(k)));
-
-                    allVariants.put(storedItem, decompressed.getInt(decompressedKeys.getLast()));
-                    allVariants.putAll(compressed);
-                } else if (!compressed.isEmpty()) {
-                    allVariants.put(
-                            storedItem,
-                            compressed.values().intStream().findFirst().orElseThrow());
-                    allVariants.putAll(compressed);
-                } else {
-                    allVariants.put(storedItem, 1);
-                }
-
+            if (compressionEnabled && storedItem.equals(filterItem) && !compressionChain.isEmpty()) {
                 var count = unitCount;
+                var variants = new ObjectArrayList<>(compressionChain.keySet());
 
-                for (var variant : allVariants.keySet()) {
-                    var compressionFactor = BigInteger.valueOf(allVariants.getInt(variant));
+                for (var i = 0; i < variants.size(); i++) {
+                    var variant = variants.get(i);
 
-                    if (count.divide(compressionFactor).signum() == 1 && variant != allVariants.lastKey()) {
-                        out.add(variant, clampedLong(count.remainder(compressionFactor), stackLimit));
-                        count = count.divide(compressionFactor);
-                    } else {
+                    if (i == variants.size() - 1) {
                         out.add(variant, clampedLong(count, stackLimit));
                         highestCompressed = variant;
-                        break;
+                    } else {
+                        var nextVariant = variants.get(i + 1);
+                        var compressionFactor = BigInteger.valueOf(
+                                compressionChain.getLong(nextVariant) / compressionChain.getLong(variant));
+
+                        if (count.divide(compressionFactor).signum() == 1) {
+                            out.add(variant, count.remainder(compressionFactor).longValue());
+                            count = count.divide(compressionFactor);
+                        } else {
+                            out.add(variant, clampedLong(count, stackLimit));
+                            highestCompressed = variant;
+                            break;
+                        }
                     }
                 }
             } else {
@@ -287,8 +241,7 @@ public class BulkCellInventory implements StorageCell {
 
     @Override
     public boolean isPreferredStorageFor(AEKey what, IActionSource source) {
-        return what instanceof AEItemKey item
-                && (partitionList.isListed(item) || compressed.containsKey(item) || decompressed.containsKey(item));
+        return what instanceof AEItemKey item && (filterItem.equals(item) || compressionChain.containsKey(item));
     }
 
     @Override

--- a/common/src/main/java/gripe/_90/megacells/service/CompressionService.java
+++ b/common/src/main/java/gripe/_90/megacells/service/CompressionService.java
@@ -1,59 +1,48 @@
 package gripe._90.megacells.service;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import it.unimi.dsi.fastutil.Pair;
-import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2LongLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.item.crafting.RecipeType;
 
 import appeng.api.stacks.AEItemKey;
 
-public class CompressionService {
-    // Each chain is an ordered map with the items themselves as the keys and the values being the amount of either:
-    // - the item itself, needed to compress to its next variant
-    // - the next variant, when decompressing the item
-    // This value is typically either 4 or 9 for any given item.
-    private static final Set<Object2IntMap<AEItemKey>> compressionChains = new ObjectLinkedOpenHashSet<>();
+import gripe._90.megacells.definition.MEGATags;
 
-    public static Optional<Object2IntMap<AEItemKey>> getChain(AEItemKey key) {
+public class CompressionService {
+    // Each chain is an ordered map with the items themselves as the keys and the values being how much of the smallest
+    // "unit" item in the chain makes up each subsequent variant item.
+    // e.g. 1 nugget -> 9 nuggets per ingot -> 81 nuggets per block -> etc.
+    private static final Set<Object2LongMap<AEItemKey>> compressionChains = new ObjectLinkedOpenHashSet<>();
+
+    // It may be desirable for some items to be included as variants in a chain in spite of any recipes involving those
+    // items not being reversible. Hence, we override any reversibility checks and generate a variant for such an item
+    // based on its usually irreversible recipe.
+    private static final Set<Override> overrides = new ObjectLinkedOpenHashSet<>();
+
+    public static Optional<Object2LongMap<AEItemKey>> getChain(AEItemKey key) {
         return compressionChains.stream()
                 .filter(chain -> chain.containsKey(key))
                 .findFirst();
     }
 
-    public static Object2IntMap<AEItemKey> getVariants(AEItemKey key, boolean decompress) {
-        return getChain(key)
-                .map(chain -> {
-                    var keys = new ObjectArrayList<>(chain.keySet());
-
-                    // Reverse ordering when going from provided storage/filter variant to least-compressed "base unit"
-                    if (decompress) {
-                        Collections.reverse(keys);
-                    }
-
-                    // Split variant chain into separate compressed/decompressed chains, omitting the initial variant
-                    // provided
-                    var variants = new Object2IntLinkedOpenHashMap<AEItemKey>();
-                    keys.subList(keys.indexOf(key) + 1, keys.size()).forEach(k -> variants.put(k, chain.getInt(k)));
-                    return variants;
-                })
-                .orElseGet(Object2IntLinkedOpenHashMap::new);
-    }
-
     public static void loadRecipes(RecipeManager recipeManager, RegistryAccess access) {
         // Clear old variant cache in case of the server restarting or recipes being reloaded
         compressionChains.clear();
+        overrides.clear();
 
         // Retrieve all available "compression" and "decompression" recipes from the current server's recipe manager
         var allRecipes = recipeManager.getAllRecipesFor(RecipeType.CRAFTING);
@@ -74,33 +63,112 @@ public class CompressionService {
                 .toList();
 
         // Pull all available compression chains from the recipe shortlist and add these to the cache
-        for (var recipe : compressed) {
+        for (var recipe :
+                Stream.concat(compressed.stream(), decompressed.stream()).toList()) {
             var baseVariant = recipe.getResultItem(access).getItem();
 
             if (compressionChains.stream().noneMatch(chain -> chain.containsKey(AEItemKey.of(baseVariant)))) {
-                var newChain = generateChain(baseVariant, compressed, decompressed, access);
-
-                if (!newChain.isEmpty()) {
-                    compressionChains.add(newChain);
-                }
+                compressionChains.add(generateChain(baseVariant, compressed, decompressed, access));
             }
         }
     }
 
-    private static boolean isCompressionRecipe(CraftingRecipe recipe, RegistryAccess access) {
-        return (recipe.getIngredients().size() == 4 || recipe.getIngredients().size() == 9)
-                && recipe.getIngredients().stream().distinct().count() <= 1
-                && recipe.getResultItem(access).getCount() == 1;
+    private static Object2LongMap<AEItemKey> generateChain(
+            Item baseVariant,
+            List<CraftingRecipe> compressed,
+            List<CraftingRecipe> decompressed,
+            RegistryAccess access) {
+        var chain = new Object2LongLinkedOpenHashMap<AEItemKey>();
+        var compressionFactor = 1L;
+
+        for (var lower = getNextVariant(baseVariant, decompressed, false, access); lower != null; ) {
+            baseVariant = lower.first();
+            lower = getNextVariant(baseVariant, decompressed, false, access);
+        }
+
+        chain.put(AEItemKey.of(baseVariant), compressionFactor);
+
+        for (var higher = getNextVariant(baseVariant, compressed, true, access); higher != null; ) {
+            compressionFactor *= higher.second();
+            chain.put(AEItemKey.of(higher.first()), compressionFactor);
+            higher = getNextVariant(higher.first(), compressed, true, access);
+        }
+
+        return chain;
+    }
+
+    private static Pair<Item, Integer> getNextVariant(
+            Item item, List<CraftingRecipe> recipes, boolean compressed, RegistryAccess access) {
+        for (var override : overrides) {
+            if (override.smaller.equals(item) && compressed) {
+                return Pair.of(override.larger, override.factor);
+            }
+
+            if (override.larger.equals(item) && !compressed) {
+                return Pair.of(override.smaller, override.factor);
+            }
+        }
+
+        for (var recipe : recipes) {
+            for (var input : recipe.getIngredients().get(0).getItems()) {
+                if (input.getItem().equals(item)) {
+                    return Pair.of(
+                            recipe.getResultItem(access).getItem(),
+                            compressed
+                                    ? recipe.getIngredients().size()
+                                    : recipe.getResultItem(access).getCount());
+                }
+            }
+        }
+
+        return null;
     }
 
     private static boolean isDecompressionRecipe(CraftingRecipe recipe, RegistryAccess access) {
-        return (recipe.getResultItem(access).getCount() == 4
-                        || recipe.getResultItem(access).getCount() == 9)
-                && recipe.getIngredients().size() == 1;
+        return recipe.getIngredients().size() == 1
+                && Set.of(4, 9).contains(recipe.getResultItem(access).getCount());
+    }
+
+    private static boolean isCompressionRecipe(CraftingRecipe recipe, RegistryAccess access) {
+        return sameIngredient(recipe)
+                && recipe.getResultItem(access).getCount() == 1
+                && Set.of(4, 9).contains(recipe.getIngredients().size());
+    }
+
+    // All this for some fucking melons.
+    private static boolean sameIngredient(CraftingRecipe recipe) {
+        var ingredients = new ObjectArrayList<>(recipe.getIngredients());
+
+        if (ingredients.isEmpty()) {
+            return false;
+        }
+
+        var first = ingredients.remove(0).getItems();
+        if (first.length == 0) return false;
+
+        for (var ingredient : ingredients) {
+            var stacks = ingredient.getItems();
+
+            if (stacks.length != first.length) {
+                return false;
+            }
+
+            for (var i = 0; i < stacks.length; i++) {
+                if (!ItemStack.isSameItemSameTags(stacks[i], first[i])) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     private static boolean isReversibleRecipe(
             CraftingRecipe recipe, List<CraftingRecipe> candidates, RegistryAccess access) {
+        if (overrideRecipe(recipe, access)) {
+            return true;
+        }
+
         var compressible = false;
         var decompressible = false;
 
@@ -126,61 +194,20 @@ public class CompressionService {
         return false;
     }
 
-    private static Object2IntMap<AEItemKey> generateChain(
-            Item baseVariant,
-            List<CraftingRecipe> compressed,
-            List<CraftingRecipe> decompressed,
-            RegistryAccess access) {
-        var decompressionChain = new Object2IntLinkedOpenHashMap<AEItemKey>();
+    private static boolean overrideRecipe(CraftingRecipe recipe, RegistryAccess access) {
+        for (var item : recipe.getIngredients().get(0).getItems()) {
+            if (item.is(MEGATags.COMPRESSION_OVERRIDES)) {
+                var variant = recipe.getResultItem(access);
+                var compressed = isCompressionRecipe(recipe, access);
+                var factor = compressed ? recipe.getIngredients().size() : variant.getCount();
 
-        for (var lower = getNextVariant(baseVariant, decompressed, access); lower != null; ) {
-            decompressionChain.put(AEItemKey.of(lower.first()), (int) lower.second());
-            lower = getNextVariant(lower.first(), decompressed, access);
-        }
-
-        var compressionChain = new Object2IntLinkedOpenHashMap<AEItemKey>();
-
-        for (var higher = getNextVariant(baseVariant, compressed, access); higher != null; ) {
-            compressionChain.put(AEItemKey.of(higher.first()), (int) higher.second());
-            higher = getNextVariant(higher.first(), compressed, access);
-        }
-
-        // Collate decompression and compression chains together with base variant
-        var fullChain = new Object2IntLinkedOpenHashMap<AEItemKey>();
-
-        // In theory this shouldn't even be happening by this point
-        if (compressionChain.isEmpty() && decompressionChain.isEmpty()) return fullChain;
-
-        // By default, full chains go from the smallest "unit" variant to the most compressed, so reverse the
-        // decompression chain and add it first
-        var decompressionKeys = new ObjectArrayList<>(decompressionChain.keySet());
-        Collections.reverse(decompressionKeys);
-        decompressionKeys.forEach(k -> fullChain.put(k, decompressionChain.getInt(k)));
-
-        // Retrieve appropriate multiplier for base variant for completion's sake
-        fullChain.put(
-                AEItemKey.of(baseVariant),
-                fullChain.isEmpty()
-                        ? compressionChain.getInt(compressionChain.firstKey())
-                        : fullChain.getInt(fullChain.lastKey()));
-
-        fullChain.putAll(compressionChain);
-        return fullChain;
-    }
-
-    private static Pair<Item, Integer> getNextVariant(Item item, List<CraftingRecipe> recipes, RegistryAccess access) {
-        for (var recipe : recipes) {
-            for (var input : recipe.getIngredients().get(0).getItems()) {
-                if (input.getItem().equals(item)) {
-                    return Pair.of(
-                            recipe.getResultItem(access).getItem(),
-                            isCompressionRecipe(recipe, access)
-                                    ? recipe.getIngredients().size()
-                                    : recipe.getResultItem(access).getCount());
-                }
+                overrides.add(new Override(item.getItem(), variant.getItem(), compressed, factor));
+                return true;
             }
         }
 
-        return null;
+        return false;
     }
+
+    private record Override(Item smaller, Item larger, boolean compressed, int factor) {}
 }

--- a/fabric/src/data/java/gripe/_90/megacells/datagen/MEGADataGenerators.java
+++ b/fabric/src/data/java/gripe/_90/megacells/datagen/MEGADataGenerators.java
@@ -14,9 +14,9 @@ public class MEGADataGenerators implements DataGeneratorEntrypoint {
         var pack = generator.createPack();
         var registries = CompletableFuture.supplyAsync(VanillaRegistries::createLookup, Util.backgroundExecutor());
 
-        var blockTags = pack.addProvider((FabricDataOutput output) -> new CommonTagProvider.Blocks(output, registries));
+        var blocks = pack.addProvider((FabricDataOutput output) -> new CommonTagProvider.BlockTags(output, registries));
         pack.addProvider((FabricDataOutput output) ->
-                new CommonTagProvider.Items(output, registries, blockTags.contentsGetter()));
+                new CommonTagProvider.ItemTags(output, registries, blocks.contentsGetter()));
 
         pack.addProvider(ModelProvider::new);
         pack.addProvider(RecipeProvider::new);

--- a/forge/src/data/java/gripe/_90/megacells/datagen/MEGADataGenerators.java
+++ b/forge/src/data/java/gripe/_90/megacells/datagen/MEGADataGenerators.java
@@ -19,8 +19,8 @@ public class MEGADataGenerators {
         var existing = event.getExistingFileHelper();
         var registries = CompletableFuture.supplyAsync(VanillaRegistries::createLookup, Util.backgroundExecutor());
 
-        var blockTags = pack.addProvider(output -> new CommonTagProvider.Blocks(output, registries));
-        pack.addProvider(output -> new CommonTagProvider.Items(output, registries, blockTags.contentsGetter()));
+        var blockTags = pack.addProvider(output -> new CommonTagProvider.BlockTags(output, registries));
+        pack.addProvider(output -> new CommonTagProvider.ItemTags(output, registries, blockTags.contentsGetter()));
 
         pack.addProvider(output -> new ModelProvider.Items(output, existing));
         pack.addProvider(output -> new ModelProvider.Blocks(output, existing));


### PR DESCRIPTION
Throughout the existence of the bulk cell compression mechanic, it turned out that there were some imperfections with the system as was written. Mainly, this meant that the system would be unfit to properly handle compression chains where the multiplier from one variant to the next changes between 4 or 9 — say, a block requiring 4 of a resource and a compressed version of the block then requiring 9 of those blocks.

This PR significantly improves and reworks the compression system in the following two ways:

- Compression chains are now stored in the same order of items, but now instead hold an overall multiplier corresponding to how much of the smallest base unit makes up each variant. In other words, the multiplier now starts at 1 for a nugget, followed by 9 nuggets for one ingot, 81 nuggets for one block, and so on.
- It is now possible to *override* the reversibility check for a recipe in order to allow various items to be compressed that typically wouldn't be able to be decompressed again, such as Nether quartz to quartz blocks and amethyst shards to amethyst blocks. This works much the same way as [the system used by Functional Storage](https://github.com/Buuz135/FunctionalStorage/blob/main/src/main/java/com/buuz135/functionalstorage/util/CompactingUtil.java#L120), in which a tag is checked for items whose recipes should override the check.

With the second improvement mentioned, this PR closes #58.