### PR TITLE
update to new ae2wtlib api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,8 @@ java.toolchain.languageVersion = JavaLanguageVersion.of(21)
 
 dependencies {
     implementation(libs.ae2)
-    implementation(libs.ae2wtlib)
+    implementation(libs.ae2wtlibapi)
+    runtimeOnly(libs.ae2wtlib)
 
     implementation(libs.appmek)
     compileOnly(libs.mekanism)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ run {
                 content {
                     includeGroup("appeng")
                     includeGroup("mekanism")
+                    includeGroup("de.mari_023")
                 }
             }
 
@@ -50,7 +51,9 @@ run {
                 version("ae2", "19.0.12-alpha")
                 library("ae2", "appeng", "appliedenergistics2").versionRef("ae2")
 
-                library("ae2wtlib", "maven.modrinth", "applied-energistics-2-wireless-terminals").version("WyPbb8sE")
+                version("ae2wtlib", "19.1.0-alpha.1")
+                library("ae2wtlib", "de.mari_023", "ae2wtlib").versionRef("ae2wtlib")
+                library("ae2wtlibapi", "de.mari_023", "ae2wtlib_api").versionRef("ae2wtlib")
 
                 library("appmek", "maven.modrinth", "applied-mekanistics").version("yh6fz02r")
                 library("mekanism", "mekanism", "Mekanism").version("$mc-10.6.5.52")

--- a/src/main/java/gripe/_90/megacells/MEGACells.java
+++ b/src/main/java/gripe/_90/megacells/MEGACells.java
@@ -142,7 +142,7 @@ public class MEGACells {
                 Upgrades.add(MEGAItems.GREATER_ENERGY_CARD, portableCell, 2, portableCellGroup);
             }
 
-            if (Addons.AE2WTLIB.isLoaded()) {
+            if (Addons.AE2WTLIB_API.isLoaded()) {
                 AE2WTIntegration.initUpgrades();
             }
 

--- a/src/main/java/gripe/_90/megacells/integration/Addons.java
+++ b/src/main/java/gripe/_90/megacells/integration/Addons.java
@@ -11,7 +11,7 @@ public enum Addons {
     APPBOT("Applied Botanics"),
     ARSENG("Ars Énergistique"),
     APPLIEDE("AppliedE"),
-    AE2WTLIB("AE2WTLib");
+    AE2WTLIB_API("AE2WTLib API");
 
     private final String modName;
 

--- a/src/main/java/gripe/_90/megacells/integration/ae2wt/AE2WTIntegration.java
+++ b/src/main/java/gripe/_90/megacells/integration/ae2wt/AE2WTIntegration.java
@@ -2,7 +2,7 @@ package gripe._90.megacells.integration.ae2wt;
 
 import static gripe._90.megacells.definition.MEGAItems.GREATER_ENERGY_CARD;
 
-import de.mari_023.ae2wtlib.UpgradeHelper;
+import de.mari_023.ae2wtlib.api.registration.UpgradeHelper;
 
 public final class AE2WTIntegration {
     public static void initUpgrades() {


### PR DESCRIPTION
ae2wtlib is getting a new api which is supposed to be JiJed by mods adding their own terminals.
this has the advantage that the terminal related code isn't duplicated between ae2wtlib present and ae2wtlib not present.
it is however also a breaking change for all mods interacting with ae2wtlib, so I am making this PR before I release the ae2wtlib update publicly in order to minimize the impact

I marked megacells  <= 4.0.0-alpha incompatible in ae2wtlib (but excluded 0.0.0 so it works in dev)
since this now uses the api mod, there shouldn't be any weird issues with people accidentally using an old ae2wtlib version with this PR (except that they couldn't put greater energy cards in ae2wtlib terminals)

I will probably release the ae2wtlib update today or tomorrow